### PR TITLE
Use config `default_admonition_type`

### DIFF
--- a/versionwarning/banner.py
+++ b/versionwarning/banner.py
@@ -49,8 +49,8 @@ class VersionWarningBanner(object):
             return None
 
         node_class = self.ADMONITION_TYPES.get(
-            admonition_type,
-            self.ADMONITION_TYPES.get(self._default_admonition_type),
+            self._default_admonition_type,
+            self.ADMONITION_TYPES.get(admonition_type),
         )
 
         if self._message_placeholder in message:


### PR DESCRIPTION
Example:

![captura de pantalla_2018-07-30_20-38-40](https://user-images.githubusercontent.com/244656/43429220-982b3082-9438-11e8-82a6-3c7b968539fe.png)

Live testing: https://sphinx-version-warning-example.readthedocs.io/en/alabaster-note/